### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Read [here](https://github.com/joltwallet/esp_littlefs/blob/master/Kconfig) and 
  ```python
  Import("env")
  print("Replace MKSPIFFSTOOL with mklittlefs.exe")
- env.Replace (MKSPIFFSTOOL = "mklittlefs.exe")
+ env.Replace (MKSPIFFSTOOL = "mklittlefs.exe")    # PlatformIO now believes it has actually created a SPIFFS
+ #env.Replace( MKSPIFFSTOOL = env.get("PROJECT_DIR") + '/mklittlefs' )    # use this line if above not work.
  ```
  
 - Add _mklittlefs.exe_ to project root directory as well.


### PR DESCRIPTION
add a comment to make it clear, since platformIO still creating the `spiffs.bin` for filesystem image. The file name `spiffs.bin` is so much CONFUSING! it makes the user fill the LittleFS creating is fail.