### PR TITLE
Fixed `LITTLEFSimpl::exists()` error: Fix lorol/LITTLEFS#43

### DIFF
--- a/src/LITTLEFS.cpp
+++ b/src/LITTLEFS.cpp
@@ -41,7 +41,7 @@ LITTLEFSImpl::LITTLEFSImpl()
 
 bool LITTLEFSImpl::exists(const char* path)
 {
-    File f = open(path, "r");
+    File f = open(path, "r", false);
     return (f == true);
 }
 


### PR DESCRIPTION
LitteFS fails to compile, resulting in this error:
```
Compiling .pio/build/esp32dev/lib63a/LittleFS_esp32/LITTLEFS.cpp.o
.pio/libdeps/esp32dev/LittleFS_esp32/src/LITTLEFS.cpp: In member function 'virtual bool LITTLEFSImpl::exists(const char*)':
.pio/libdeps/esp32dev/LittleFS_esp32/src/LITTLEFS.cpp:44:28: error: no matching function for call to 'LITTLEFSImpl::open(const char*&, const char [2])'
     File f = open(path, "r");
In file included from .pio/libdeps/esp32dev/LittleFS_esp32/src/LITTLEFS.cpp:17:
/home/hari/.platformio/packages/framework-arduinoespressif32/libraries/FS/src/vfs_api.h:38:17: note: candidate: 'virtual fs::FileImplPtr VFSImpl::open(const char*, const char*, bool)'
     FileImplPtr open(const char* path, const char* mode, const bool create) override;
                 ^~~~
/home/hari/.platformio/packages/framework-arduinoespressif32/libraries/FS/src/vfs_api.h:38:17: note:   candidate expects 3 arguments, 2 provided
*** [.pio/build/esp32dev/lib63a/LittleFS_esp32/LITTLEFS.cpp.o] Error 1
```

Fixed by adding a third argument to the call to the open function as shown below.
```cpp
File f = open(path, "r");        // Current
File f = open(path, "r", false); // My Fix
```

This function call is located on line 44 of `src/LITTLEFS.cpp`:
```cpp
bool LITTLEFSImpl::exists(const char* path)
{
    File f = open(path, "r", false);
    return (f == true);
}
```